### PR TITLE
Indicate the password is in plain text

### DIFF
--- a/django_pwnedpasswords_validator/validation.py
+++ b/django_pwnedpasswords_validator/validation.py
@@ -27,7 +27,7 @@ class PwnedPasswordValidator(object):
         self.error_text = error_text
 
     def validate(self, password, user=None):
-        count = pwnedpasswords.check(password, anonymous=self.anonymous)
+        count = pwnedpasswords.check(password, anonymous=self.anonymous, plain_text=True)
         if count > 0:
             raise ValidationError(_(self.error_text), code="password_is_pwned")
 


### PR DESCRIPTION
Without this, the pwnedpasswords module tries to detect it and it might misinterpret passwords which look like sha1 hash.